### PR TITLE
Flask answer route testing

### DIFF
--- a/server/app/routes/answer.py
+++ b/server/app/routes/answer.py
@@ -40,21 +40,21 @@ def answer_routes(app):
         webm_file.save(webm_file_path)
 
         # convert webm file to wav
-        convert_to_wav(file_path)
         app.logger.info(
-            "Coverting answer .webm for question[%s] by user[%s] to .wav file",
+            "Converting answer .webm for question[%s] by user[%s] to .wav file",
             question_id,
             user_id,
         )
+        convert_to_wav(file_path)
 
         # upload to bucket
-        upload_file(GCS_BUCKET, gcs_path, wav_file_path)
         app.logger.info(
             "Uploaded answer .wav for question[%s] by user[%s] to %s",
             question_id,
             user_id,
             get_blob_url(GCS_BUCKET, gcs_path),
         )
+        upload_file(GCS_BUCKET, gcs_path, wav_file_path)
 
         # add file path to question doc in db
         question = add_answer(question_id, gcs_path)

--- a/server/app/routes/answer.py
+++ b/server/app/routes/answer.py
@@ -49,7 +49,7 @@ def answer_routes(app):
 
         # upload to bucket
         app.logger.info(
-            "Uploaded answer .wav for question[%s] by user[%s] to %s",
+            "Uploading answer .wav for question[%s] by user[%s] to %s",
             question_id,
             user_id,
             get_blob_url(GCS_BUCKET, gcs_path),

--- a/server/app/utils/gcs.py
+++ b/server/app/utils/gcs.py
@@ -29,6 +29,18 @@ def upload_file(bucket_name, blob, destination):
     blob.upload_from_filename(destination)
 
 
+def delete_file(bucket_name, blob):
+    """
+    Delete a file on the google cloud storage bucket
+
+    @param: bucket_name - Name of GCS bucket
+    @param: blob        - Name of blob to be deleted from GCS bucket
+    """
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob)
+    blob.delete()
+
 def get_blob_url(bucket, blob_path):
     return f"gs://{bucket}/{blob_path}"
 

--- a/server/tests/integration/test_answers.py
+++ b/server/tests/integration/test_answers.py
@@ -1,5 +1,6 @@
 import pytest
 import io
+import os
 from bson import ObjectId
 from tests.utils import (
     get_test_app,
@@ -7,8 +8,14 @@ from tests.utils import (
     set_test_cookie,
     build_question,
     generate_sample_webm,
-    cleanup_webm
+    cleanup_webm,
+    get_test_blob_url
 )
+from app.utils.constants import ( 
+    TMP_DIR, 
+    WAV_EXT, 
+    WEBM_EXT 
+) 
 
 @pytest.fixture
 def app():
@@ -49,9 +56,22 @@ class TestSubmitAnswer:
         set_test_cookie(app, uid)
         question_id = build_question("test question", uid)["_id"]
 
+        webm_path = f"{TMP_DIR}/{question_id}{WEBM_EXT}"
         webm = generate_sample_webm(question_id)
+        assert webm
+        assert os.path.exists(webm_path) is True
 
         res = app.post(f"/api/questions/{question_id}/answer", data=dict(audio=webm), content_type='multipart/form-data')
         assert res.status_code == 201
 
+        question_response = res.json.get("question")
+        assert question_response
+        assert len(question_response) >= 1
+
+        blob_path = f"{uid}/{question_id}{WAV_EXT}"
+        blob_url = res.json.get("question").get("answer")
+        assert blob_url
+        assert blob_url == get_test_blob_url(blob_path)
+
         cleanup_webm(uid, question_id)
+        assert os.path.exists(webm_path) is False

--- a/server/tests/integration/test_answers.py
+++ b/server/tests/integration/test_answers.py
@@ -1,0 +1,57 @@
+import pytest
+import io
+from bson import ObjectId
+from tests.utils import (
+    get_test_app,
+    drop_all_collections,
+    set_test_cookie,
+    build_question,
+    generate_sample_webm,
+    cleanup_webm
+)
+
+@pytest.fixture
+def app():
+    app = get_test_app()
+    yield app
+    drop_all_collections()
+
+
+#########################################################
+## POST /api/questions/<question_id>/answer Test Cases ##
+#########################################################
+
+
+class TestSubmitAnswer:
+    def test_submit_answer_400(self, app):
+        """
+        POST /api/questions/<question_id>/answer: uses malformed file ending
+        """
+        uid = str(ObjectId())
+        set_test_cookie(app, uid)
+
+        file = dict(audio=(io.BytesIO(str.encode(uid)), 'test.txt'))
+        res = app.post(f"/api/questions/{str(ObjectId())}/answer", data=file, content_type='multipart/form-data')
+        assert res.status_code == 400
+    
+    def test_submit_answer_401(self, app):
+        """
+        POST /api/questions/<question_id>/answer: accessing endpoint without user permission
+        """
+        res = app.post(f"/api/questions/{str(ObjectId())}/answer")
+        assert res.status_code == 401
+
+    def test_submit_answer_201(self, app):
+        """
+        POST /api/questions/<question_id>/answer: submit proper file and check local directories
+        """
+        uid = str(ObjectId())
+        set_test_cookie(app, uid)
+        question = build_question("test question", uid)["_id"]
+
+        webm = generate_sample_webm(question)
+        
+        res = app.post(f"/api/questions/{question}/answer", data=dict(audio=webm), content_type='multipart/form-data')
+        assert res.status_code == 201
+
+        cleanup_webm(question)

--- a/server/tests/integration/test_answers.py
+++ b/server/tests/integration/test_answers.py
@@ -47,11 +47,11 @@ class TestSubmitAnswer:
         """
         uid = str(ObjectId())
         set_test_cookie(app, uid)
-        question = build_question("test question", uid)["_id"]
+        question_id = build_question("test question", uid)["_id"]
 
-        webm = generate_sample_webm(question)
-        
-        res = app.post(f"/api/questions/{question}/answer", data=dict(audio=webm), content_type='multipart/form-data')
+        webm = generate_sample_webm(question_id)
+
+        res = app.post(f"/api/questions/{question_id}/answer", data=dict(audio=webm), content_type='multipart/form-data')
         assert res.status_code == 201
 
-        cleanup_webm(question)
+        cleanup_webm(uid, question_id)

--- a/server/tests/utils.py
+++ b/server/tests/utils.py
@@ -1,6 +1,8 @@
 from bson import ObjectId
 from pymongo import MongoClient
+from werkzeug.datastructures import FileStorage
 import os
+import subprocess
 
 from app.factory import create_flask
 from app.mongodb.queries import create_question
@@ -52,3 +54,35 @@ def build_questions(uid, n=5):
     for i in range(n):
         questions[i] = build_question(f"Question {i+1}", uid)
     return questions
+
+def generate_sample_webm(question_id):
+    """
+    Generate a sample webm file from a question id for testing 
+    """
+    # ffmpeg -f lavfi -i "sine=frequency=1000:duration=5" test.webm
+    command = [
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=1000:duration=5",
+        f"{question_id}.webm"
+    ]
+    subprocess.run(command, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+
+    return retrieve_sample_webm(question_id)
+
+def retrieve_sample_webm(question_id):
+    file = f"{question_id}.webm"
+
+    webm = FileStorage(
+        stream=open(file, "rb"),
+        filename=f"{question_id}.webm",
+        content_type="video/webm"
+    )
+    
+    return webm
+
+def cleanup_webm(question_id):
+    if os.path.exists(f"{question_id}.webm"):
+        os.remove(f"{question_id}.webm")

--- a/server/tests/utils.py
+++ b/server/tests/utils.py
@@ -111,4 +111,7 @@ def cleanup_webm(uid, question_id):
 
 
 def get_test_blob_url(blob_path):
+    """
+    Retrieve blob url using test question data and path
+    """
     return get_blob_url(GCS_BUCKET, blob_path)

--- a/server/tests/utils.py
+++ b/server/tests/utils.py
@@ -8,6 +8,7 @@ from app.factory import create_flask
 from app.mongodb.queries import create_question
 from app.mongodb.utils import serialize_id
 from app.utils.constants import USER_COOKIE_KEY
+from app.utils.misc import delete_local_file
 from app.utils.gcs import ( 
     delete_file, 
     get_blob_url 
@@ -104,7 +105,7 @@ def cleanup_webm(uid, question_id):
     """
     local_path = f"{TMP_DIR}/{question_id}{WEBM_EXT}"
     if os.path.exists(local_path):
-        os.remove(local_path)
+        delete_local_file(local_path)
 
     gcs_path = f"{uid}/{question_id}{WAV_EXT}"
     delete_file(GCS_BUCKET, gcs_path)

--- a/server/tests/utils.py
+++ b/server/tests/utils.py
@@ -8,6 +8,8 @@ from app.factory import create_flask
 from app.mongodb.queries import create_question
 from app.mongodb.utils import serialize_id
 from app.utils.constants import USER_COOKIE_KEY
+from app.utils.gcs import delete_file
+from app.utils.constants import GCS_BUCKET, WAV_EXT
 
 mongo = MongoClient(os.getenv("TEST_MONGO_URI"))
 db = mongo["test_db"]
@@ -83,6 +85,9 @@ def retrieve_sample_webm(question_id):
     
     return webm
 
-def cleanup_webm(question_id):
+def cleanup_webm(uid, question_id):
     if os.path.exists(f"{question_id}.webm"):
         os.remove(f"{question_id}.webm")
+
+    gcs_path = f"{uid}/{question_id}{WAV_EXT}"
+    delete_file(GCS_BUCKET, gcs_path)


### PR DESCRIPTION
- Added tests for 400, 401, and 201 status' in the `/api/questions/<question_id>/answer` route
  - 400: tests malformed file ending
  - 401: accesses endpoint without permission
  - 201: creates sample .webm file locally and uploads it to gcs bucket, then cleans up bucket and local directories after execution